### PR TITLE
[Chore] update state_beacon to v3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  state_beacon: ^1.3.4
+  state_beacon: ^3.0.0
 
 dev_dependencies:
   coverage: ^1.15.0


### PR DESCRIPTION
Hey, this is just a tiny PR to update statebeacon to v3. All tests passes so no changes are needed.

I am thinking of submitting a PR that uses BeaconController for DashboardControllerImpl.

ie:
```dart
class DashboardControllerImpl with BeaconController implements DashboardController
```

Pros:

- No need to manually dispose each beacon
- beacon are created lazily since they are late variables. This improves memory pressure as it avoids creating all the beacons when the class in instantiated.