### PR TITLE
Fix invalid pointer location in items.

### DIFF
--- a/example/lib/main_sliver.dart
+++ b/example/lib/main_sliver.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:example/pointer_dot_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:sliver_dashboard/sliver_dashboard.dart';
 
@@ -464,6 +465,7 @@ class MyCard extends StatelessWidget {
       elevation: 2,
       color: color,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      clipBehavior: Clip.antiAlias,
       child: Stack(
         children: [
           Center(
@@ -481,6 +483,9 @@ class MyCard extends StatelessWidget {
               ],
             ),
           ),
+          if (!isEditing) ...[
+            Positioned.fill(child: PointerDotWidget(child: SizedBox())),
+          ],
           if (isEditing && !item.isStatic)
             Positioned(
               top: 4,

--- a/example/lib/pointer_dot_widget.dart
+++ b/example/lib/pointer_dot_widget.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+/// A widget that paints a dot at the location of the pointer when the user
+/// presses down on it.
+class PointerDotWidget extends StatefulWidget {
+  /// The child widget.
+  final Widget child;
+
+  const PointerDotWidget({super.key, required this.child});
+
+  @override
+  State<PointerDotWidget> createState() => _PointerDotWidgetState();
+}
+
+class _PointerDotWidgetState extends State<PointerDotWidget> {
+  Offset? _position;
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: (event) {
+        setState(() {
+          _position = event.localPosition;
+        });
+      },
+      onPointerMove: (event) {
+        // Only update if the pointer is down, which we infer by _position != null
+        if (_position != null) {
+          setState(() {
+            _position = event.localPosition;
+          });
+        }
+      },
+      onPointerUp: (event) {
+        setState(() {
+          _position = null;
+        });
+      },
+      onPointerCancel: (event) {
+        setState(() {
+          _position = null;
+        });
+      },
+      child: CustomPaint(painter: _DotPainter(_position), child: widget.child),
+    );
+  }
+}
+
+class _DotPainter extends CustomPainter {
+  final Offset? position;
+  final Paint _paint;
+
+  _DotPainter(this.position)
+    : _paint = Paint()
+        ..color = Colors.blue.withOpacity(0.5)
+        ..style = PaintingStyle.fill;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (position != null) {
+      canvas.drawCircle(position!, 20.0, _paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _DotPainter oldDelegate) {
+    return oldDelegate.position != position;
+  }
+}

--- a/lib/src/view/sliver_dashboard.dart
+++ b/lib/src/view/sliver_dashboard.dart
@@ -643,61 +643,6 @@ class RenderSliverDashboard extends RenderSliverMultiBoxAdaptor {
     }
   }
 
-  @override
-  bool hitTestChildren(
-    SliverHitTestResult result, {
-    required double mainAxisPosition,
-    required double crossAxisPosition,
-  }) {
-    var child = lastChild;
-    final isVertical = scrollDirection == Axis.vertical;
-    while (child != null) {
-      final parentData = child.parentData;
-      if (parentData is! SliverDashboardParentData) break;
-
-      // The `mainAxisPosition` passed to hitTestChildren is relative to the
-      // sliver's paint origin, which is the top of the visible portion.
-      // We need to compare it against the child's position, which is also
-      // relative to that same origin.
-      final childMainAxisPosition = parentData.layoutOffset! - constraints.scrollOffset;
-      final childCrossAxisPosition =
-          isVertical ? parentData.paintOffset.dx : parentData.paintOffset.dy;
-
-      final childCrossAxisExtent = isVertical ? child.size.width : child.size.height;
-      final childMainAxisExtent = isVertical ? child.size.height : child.size.width;
-
-      if (mainAxisPosition >= childMainAxisPosition &&
-          mainAxisPosition < childMainAxisPosition + childMainAxisExtent &&
-          crossAxisPosition >= childCrossAxisPosition &&
-          crossAxisPosition < childCrossAxisPosition + childCrossAxisExtent) {
-        // The hit is within the child's bounds, so we now convert to the
-        // child's local coordinate system to perform the final hit test.
-        final localCrossAxis = crossAxisPosition - childCrossAxisPosition;
-        final localMainAxis = mainAxisPosition - childMainAxisPosition;
-
-        if (child.hitTest(
-          BoxHitTestResult.wrap(result),
-          position: isVertical
-              ? Offset(localCrossAxis, localMainAxis)
-              : Offset(localMainAxis, localCrossAxis),
-        )) {
-          // The hit was successful, so we have found our target.
-          // Add the child to the result and report the hit.
-          result.add(
-            SliverHitTestEntry(
-              this,
-              mainAxisPosition: mainAxisPosition,
-              crossAxisPosition: crossAxisPosition,
-            ),
-          );
-          return true;
-        }
-      }
-      child = childBefore(child);
-    }
-    return false;
-  }
-
   // override childMainAxisPosition, childCrossAxisPosition and applyPaintTransform
   // to ensure consistency with the paint logic and Flutter's tooltips alignment.
   @override


### PR DESCRIPTION
The pointer location in items inside the `SliverDashboard` are not calculated correctly. (Except for the top left most cell).

I added a "Dot Painter" to the example which paints a circle at the current mouse position when it is clicked. In the current version it won't work. I have migrated from flutter's `SliverGrid` which is has the same base class and so checked how it implemented `hitTestChildren`.. but it didn't. So I also tried to remove it from `SliverDashboard` and it started to work for me. Not sure in what cases this is required?

before (the empty circle line is added by the screenrecorder of macos to show mouse clicks):

https://github.com/user-attachments/assets/e830ba43-63f4-4837-9280-f1ef8b25d021

after:

https://github.com/user-attachments/assets/e8a2d660-5344-4715-b78c-78095cc3c5cf


