### PR TITLE
fix: don't skip a frame on breakpoint change

### DIFF
--- a/lib/src/view/sliver_dashboard.dart
+++ b/lib/src/view/sliver_dashboard.dart
@@ -119,8 +119,6 @@ class _SliverDashboardState extends State<SliverDashboard> {
                 _controller.setSlotCount(targetSlots);
               }
             });
-            // Skip frame optimization: Return an empty Sliver
-            return const SliverToBoxAdapter(child: SizedBox.shrink());
           }
         }
 


### PR DESCRIPTION
## Problem

When the viewport width crosses a breakpoint, the grid disappears for a single frame before re-rendering with the new column count. It looks like a flicker / blink during browser resize.

Reproduction: in any responsive `SliverDashboard` (or `Dashboard` with `breakpoints`), drag the window edge slowly across a breakpoint. The grid blinks empty for one frame each time `slotCount` changes.

## Root cause

In `lib/src/view/sliver_dashboard.dart`, the responsive logic schedules `setSlotCount` in a post-frame callback and **returns an empty `SliverToBoxAdapter` for the transitioning frame**:

```dart
if (targetSlots != _controller.slotCount.value) {
  WidgetsBinding.instance.addPostFrameCallback((_) {
    if (mounted) _controller.setSlotCount(targetSlots);
  });
  // Skip frame optimization: Return an empty Sliver
  return const SliverToBoxAdapter(child: SizedBox.shrink());
}
```

The trade-off appears to be: avoid rendering one frame where `slotWidth = (newCrossAxisExtent − spacing*(oldCount−1)) / oldCount` (i.e. items in slightly-wrong-sized slots), at the cost of one fully-blank frame.

In practice the empty frame is much more visible than the slightly-mis-sized frame. A single ~16 ms frame at marginally different cell sizes is below the perceptual threshold; an empty frame is a clear flicker.

## Fix

Remove the early return so the grid renders with the previous `slotCount` on the transitioning frame. The post-frame `setSlotCount` still fires and the next paint uses the new count — items snap to their new sizes one frame later, but the grid stays visible throughout.

## Verification

Tested in a real Flutter web app with `breakpoints: {0: 2, 1118: 3, 1317: 4}` on a dashboard with ~5 mixed-size items (1×1, 2×1, 2×2). Slowly resizing across both breakpoints in either direction produces a smooth cut to the new layout, no visible flicker. The 1-frame size mismatch isn't noticeable.

## Alternatives considered

- **Expose a `transitionStyle` flag** (`skipFrame` vs `renderPrevious`) — happy to reshape this PR that way if you'd prefer to keep the current default behind a flag.
- **Animated transition** (interpolate item rects across frames) — much bigger change, separate PR territory.